### PR TITLE
Add global /home/webapps/server_key.json

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,3 +12,5 @@ default[:raven_deploy][:cache_dir] = "/vagrant/cache"
 
 default[:raven_deploy][:httpd_user] = "www-data"
 default[:raven_deploy][:httpd_group] = "www-data"
+
+default[:raven_deploy][:deploy_base_path] = "/home/webapps"

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,6 +19,7 @@ recipe "raven-deploy::install_aws_credentials", "install aws key pairs in ~/.aws
 recipe "raven-deploy::install_keys", "install application deploy keys"
 recipe "raven-deploy::install_raven_repo", "install raven yum repo on images that don't have it by default"
 recipe "raven-deploy::fetch_data_bags", "fetches chef data bags from s3"
+recipe "setup_server_key_config", "create server_key.json config"
 
 attribute "raven_deploy",
     :display_name => "Raven Deploy",

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,6 +1,7 @@
 directory node[:raven_deploy][:keys_dir]
 directory node[:raven_deploy][:attachments_dir]
 
+include_recipe "setup_server_key_config"
 include_recipe "raven-deploy::fetch_data_bags"
 include_recipe "apache2"
 include_recipe "aws"

--- a/recipes/setup_server_key_config.rb
+++ b/recipes/setup_server_key_config.rb
@@ -1,0 +1,25 @@
+
+if !node[:raven_deploy].attribute?(:developer_shortname) then
+    if !node.attribute?(:ec2) || !node[:ec2].attribute?(:instance_id) then
+            raise "EC2 vars and developer short name not set"
+    end
+    server_key = node[:ec2][:instance_id]
+else
+    server_key = node[:raven_deploy][:developer_shortname]
+end
+
+config_path = node[:raven_deploy][:deploy_base_path]
+
+directory config_path
+
+config = {
+	"server_key" => server_key
+}
+
+ruby_block "create global server_key config" do
+    block do
+        File.open("#{config_path}/server_key.json","w") do |f|
+            f.write(JSON.pretty_generate(config))
+        end
+    end
+end


### PR DESCRIPTION
This will create a global  /home/webapps/server_key.json that any thing can use to get the host id. This is currently used in site_auditor_sync to create a sqsqueue and will be used in site_auditior_grid node stuff for status info on where the crawl is happening. 
