### PR TITLE
LWRP: add npm deps lwrp

### DIFF
--- a/providers/npm_deps.rb
+++ b/providers/npm_deps.rb
@@ -1,0 +1,31 @@
+use_inline_resources if defined?(use_inline_resources)
+
+action :create do
+	prefix = new_resource.prefix
+	directory = new_resource.directory
+
+	lockfile = "#{directory}/npm-shrinkwrap.json"
+
+	if ! ::File.exists?(lockfile) then
+		raise "could not find npm.lock in #{release_path}"
+	end
+
+	checksum = Digest::MD5.file(lockfile).hexdigest
+	artifact = "npm/#{prefix}/#{prefix}-#{checksum}.tar"
+	checksum_file = "#{directory}/.npm-md5sum"
+
+	raven_deploy_tarball artifact do
+		directory directory
+		bucket "raven-deploy"
+		not_if "grep #{checksum} #{checksum_file}"
+	end
+
+	file checksum_file do
+		content checksum
+	end
+end
+
+action :delete do
+	uninstall_script = new_resource.uninstall_script
+	raise "not implemented"
+end

--- a/recipes/install_aws_credentials.rb
+++ b/recipes/install_aws_credentials.rb
@@ -2,7 +2,8 @@
 	"/root" => "root",
 	"/var/lib/jenkins" => "jenkins",
 	"/hudson" => "jenkins",
-	"/var/www" => "apache"
+	"/var/www" => "apache",
+	"/home/vagrant" => "vagrant"
 }.each do |homedir,username|
 
 	directory("#{homedir}/.aws") {

--- a/resources/npm_deps.rb
+++ b/resources/npm_deps.rb
@@ -1,0 +1,5 @@
+actions [:create, :delete]
+default_action :create
+
+attribute :prefix, :kind_of => String, :name_attribute => true
+attribute :directory, :kind_of => String


### PR DESCRIPTION
Adds a new lwrp `raven_deploy_npm_deps` to install an application's `node_modules` dependencies from a pre-built artifact.
