### PR TITLE
App Deployment: use data bags for deploy keys

### DIFF
--- a/providers/app.rb
+++ b/providers/app.rb
@@ -29,7 +29,13 @@ action :checkout do
 	else
 
 		# we got a repo, so let's deploy it
-		key_path = "/root/.ssh/#{name}-deploy.key"
+		key_path = "/tmp/deploy_#{name}"
+		file key_path do
+			sensitive true
+			mode 0600
+			content data_bag_item('deploy_keys',name)["private_key"]
+		end
+
 		wrapper_path = "/tmp/#{name}-deploy.sh"
 		file wrapper_path do
 			content "/usr/bin/env ssh -o 'StrictHostKeyChecking=no' -i '#{key_path}' $1 $2"
@@ -48,6 +54,11 @@ action :checkout do
 			create_dirs_before_symlink	([])
 		end
 	
+		[key_path,wrapper_path].each do |p|
+			file p do
+				action :delete
+			end
+		end
 	end
 
 	unless docroot.nil? then

--- a/providers/npm_deps.rb
+++ b/providers/npm_deps.rb
@@ -7,7 +7,7 @@ action :create do
 	lockfile = "#{directory}/npm-shrinkwrap.json"
 
 	if ! ::File.exists?(lockfile) then
-		raise "could not find npm.lock in #{release_path}"
+		raise "could not find npm.lock in #{directory}"
 	end
 
 	checksum = Digest::MD5.file(lockfile).hexdigest

--- a/recipes/install_keys.rb
+++ b/recipes/install_keys.rb
@@ -1,4 +1,4 @@
-raven_deploy_tarball "code-deploy-keys.tar" do
+raven_deploy_tarball "deploy-keys.tar" do
 	bucket node[:raven_deploy][:keys_bucket]
 	directory "/root/.ssh"
 end


### PR DESCRIPTION
- Switches `raven_deploy_app` provider to use the data bags as the source for the ssh private key instead of `~/.ssh/`.  
- Cleans up keys and wrappers after we're done deploying.  
- Renames `code-deploy-keys.tar` to `deploy-keys.tar`.