### PR TITLE
Bug: old chef doesnt support sensitive property

### DIFF
--- a/providers/app.rb
+++ b/providers/app.rb
@@ -31,7 +31,9 @@ action :checkout do
 		# we got a repo, so let's deploy it
 		key_path = "/tmp/deploy_#{name}"
 		file key_path do
-			sensitive true
+			if defined?(sensitive) then
+				sensitive true
+			end
 			mode 0600
 			content data_bag_item('deploy_keys',name)["private_key"]
 		end


### PR DESCRIPTION
Conditionally use `sensitive` property when it's available.